### PR TITLE
Fix invalid certificate error

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -51,6 +51,5 @@
       "prettier --write",
       "git add"
     ]
-  },
-  "proxy": "http://local-backend:4000"
+  }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,7 @@ import Lobby from './pages/Lobby'
 import axios from 'axios'
 
 const App: React.FC = () => {
-  axios.defaults.baseURL = 'https://localhost:5001'
+  axios.defaults.baseURL = 'http://localhost:5000'
 
   return (
     <BaseLayout>

--- a/server/Startup.cs
+++ b/server/Startup.cs
@@ -65,7 +65,7 @@ namespace server
         }
       }
 
-      app.UseHttpsRedirection();
+      // app.UseHttpsRedirection();
 
       app.UseRouting();
 


### PR DESCRIPTION
Browsers seem to randomly refuse the connection to the API over https (Net::ERR_CERT_INVALID).
This could be resolved using a self signed certificate.
Use http for the time being.

- Use http api route instead of https
- Deactivate https redirection