### PR TITLE
Fix PlayerItem unit test

### DIFF
--- a/client/src/components/PlayerItem/PlayerItem.test.tsx
+++ b/client/src/components/PlayerItem/PlayerItem.test.tsx
@@ -9,8 +9,7 @@ describe('PlayerItem', () => {
   })
 
   it('identifies myself if isSelf is true', () => {
-    const { getByRole } = render(<PlayerItem name='Martin' isSelf={true} />)
-    const fullName = getByRole('listitem')
-    expect(fullName).toHaveTextContent('Martin (moi)')
+    const { container } = render(<PlayerItem name='Martin' isSelf={true} />)
+    expect(container).toHaveTextContent('Martin (moi)')
   })
 })


### PR DESCRIPTION
Score management PR broke a test, as PlayerItem was refactored (removed li). This commit fixes that.